### PR TITLE
Fix extraction language name.

### DIFF
--- a/Kami/Ext/Extraction.v
+++ b/Kami/Ext/Extraction.v
@@ -3,7 +3,7 @@ Require Import Kami.Synthesize.
 Require Import Ext.BSyntax.
 
 Require Import ExtrOcamlBasic ExtrOcamlNatInt ExtrOcamlString.
-Extraction Language OCaml.
+Extraction Language Ocaml.
 
 Set Extraction Optimize.
 Set Extraction KeepSingleton.


### PR DESCRIPTION
As described in PR #7 the extraction language name needs to be `Ocaml` rather than `OCaml` to fix the build break.