### PR TITLE
only use COQPATH if EXTERNAL_DEPENDENCIES=1

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,8 +1,0 @@
-((coq-mode . ((eval . (let* ((project-root (locate-dominating-file buffer-file-name "_CoqProject"))
-                             (coqutil-folder (expand-file-name "../coqutil/src" project-root))
-                             (riscv-coq-folder (expand-file-name "../riscv-coq/src" project-root))
-                             (coq-path (lambda () (split-string (or (getenv "COQPATH") "") path-separator t))))
-                        (unless (member coqutil-folder (funcall coq-path))
-                          (setenv "COQPATH" (mapconcat #'identity (cons coqutil-folder (funcall coq-path)) path-separator)))
-                        (unless (member riscv-coq-folder (funcall coq-path))
-                          (setenv "COQPATH" (mapconcat #'identity (cons riscv-coq-folder (funcall coq-path)) path-separator))))))))

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,15 @@ coq: Makefile.coq.all
 	$(MAKE) -f Makefile.coq.all
 
 Makefile.coq.all: Makefile _CoqProject $(LIBVS) $(VS) $(EXVS) $(EXSVS) $(EXTVS)
-	$(COQBIN)coq_makefile -f _CoqProject $(LIBVS) $(VS) $(EXVS) $(EXSVS) $(EXTVS) -o Makefile.coq.all
+	@echo "Generating Makefile"
+	@$(COQBIN)coq_makefile -f _CoqProject $(LIBVS) $(VS) $(EXVS) $(EXSVS) $(EXTVS) -o Makefile.coq.all
 
 src: Makefile.coq.src
 	$(MAKE) -f Makefile.coq.src
 
 Makefile.coq.src: Makefile _CoqProject $(LIBVS) $(VS)
-	$(COQBIN)coq_makefile -f _CoqProject $(LIBVS) $(VS) -o Makefile.coq.src
+	@echo "Generating Makefile"
+	@$(COQBIN)coq_makefile -f _CoqProject $(LIBVS) $(VS) -o Makefile.coq.src
 
 clean:: Makefile.coq.all Makefile.coq.src
 	$(MAKE) -f Makefile.coq.all clean || $(MAKE) -f Makefile.coq.src clean

--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,21 @@ default_target: coq
 SUPPRESS_WARN=-arg "-w" -arg "-cannot-define-projection,-implicit-core-hint-db,-notation-overridden"
 
 ARGS_NL=-R Kami Kami\n$(SUPPRESS_WARN)\n
-ARGS=$(subst \n, ,$(ARGS_NL))
-
-_CoqProject:
-	printf -- '$(ARGS_NL)' > _CoqProject
+DEPFLAGS_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n-Q $(DEPS_DIR)/riscv-coq/src/riscv riscv\n
 
 EXTERNAL_DEPENDENCIES?=
 
+# If we get our dependencies externally, then we should not bind the local versions of things
 ifneq ($(EXTERNAL_DEPENDENCIES),1)
-COQPATH?=$(DEPS_DIR)/coqutil/src:$(DEPS_DIR)/riscv-coq/src
-export COQPATH
+ALLARGS_NL=$(DEPFLAGS_NL)$(ARGS_NL)
+else
+ALLARGS_NL=$(ARGS_NL)
 endif
+
+ALLARGS=$(subst \n, ,$(ALLARGS_NL))
+
+_CoqProject:
+	printf -- '$(ALLARGS_NL)' > _CoqProject
 
 coq: Makefile.coq.all
 	$(MAKE) -f Makefile.coq.all


### PR DESCRIPTION
While discussing https://github.com/mit-plv/bedrock2/pull/101, we found a better way of supporting COQPATH.
This PR applies this to kami.
/cc @JasonGross @joonwonc 