### PR TITLE
Future proof NatLib.v

### DIFF
--- a/Kami/Lib/NatLib.v
+++ b/Kami/Lib/NatLib.v
@@ -527,7 +527,8 @@ Proof.
 Qed.
 
 Lemma mod_0_r: forall (m: nat),
-    m mod 0 = 0.
+    m mod 0 = 
+    ltac:(match eval hnf in (1 mod 0) with | 0 => exact 0 | _ => exact m end).
 Proof.
   intros. reflexivity.
 Qed.
@@ -538,7 +539,7 @@ Lemma sub_mod_0: forall (a b m: nat),
     (a - b) mod m = 0.
 Proof.
   intros. assert (m = 0 \/ m <> 0) as C by lia. destruct C as [C | C].
-  - subst. apply mod_0_r.
+  - subst. cbn in *. now subst.
   - assert (a - b = 0 \/ b < a) as D by lia. destruct D as [D | D].
     + rewrite D. apply Nat.mod_0_l. assumption.
     + apply Nat2Z.inj. simpl.


### PR DESCRIPTION
This PR makes NatLib.v work with https://github.com/coq/coq/pull/14086 in a backwards compatible manner.
It is required to establish compatibility with bedrock2.