### PR TITLE
Adapt to coq/coq#16920

### DIFF
--- a/Kami/Lib/N_Z_nat_conversions.v
+++ b/Kami/Lib/N_Z_nat_conversions.v
@@ -17,15 +17,13 @@ Module N2Nat.
     rewrite <-? N_to_Z_to_nat.
     rewrite N2Z.inj_mod by assumption.
     apply Nat2Z.inj.
-    rewrite Zdiv.mod_Zmod.
-    - rewrite? Z2Nat.id; try apply N2Z.is_nonneg.
-      + reflexivity.
-      + pose proof (Z.mod_pos_bound (Z.of_N a) (Z.of_N b)) as Q.
-        destruct Q as [Q _].
-        * destruct b; try contradiction. simpl. constructor.
-        * exact Q.
-    - destruct b; try contradiction. simpl.
-      pose proof (Pos2Nat.is_pos p) as Q. lia.
+    rewrite Nat2Z.inj_mod.
+    rewrite? Z2Nat.id; try apply N2Z.is_nonneg.
+    - reflexivity.
+    - pose proof (Z.mod_pos_bound (Z.of_N a) (Z.of_N b)) as Q.
+      destruct Q as [Q _].
+      + destruct b; try contradiction. simpl. constructor.
+      + exact Q.
   Qed.
 
 End N2Nat.

--- a/Kami/Lib/NatLib.v
+++ b/Kami/Lib/NatLib.v
@@ -543,10 +543,10 @@ Proof.
   - assert (a - b = 0 \/ b < a) as D by lia. destruct D as [D | D].
     + rewrite D. apply Nat.mod_0_l. assumption.
     + apply Nat2Z.inj. simpl.
-      rewrite Zdiv.mod_Zmod by assumption.
+      rewrite Nat2Z.inj_mod.
       rewrite Nat2Z.inj_sub by lia.
       rewrite Zdiv.Zminus_mod.
-      rewrite <-! Zdiv.mod_Zmod by assumption.
+      rewrite <-! Nat2Z.inj_mod.
       rewrite H. rewrite H0.
       apply Z.mod_0_l.
       lia.


### PR DESCRIPTION
Use `Nat2Z.inj_mod` instead of deprecated `Zdiv.mod_Zmod` (coq/coq#16920).